### PR TITLE
Change PCF Dev memory reqs from 1.5 GB to 4 GB

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -37,7 +37,7 @@ PCF Dev mirrors [PCF](../pivotalcf/installing/pcf-docs.html) in its key product 
 |                                                                           | PCF Dev                    | PCF                                   | CF            |
 | ---                                                                       | ---                        | ---                                   | ---           |
 | Space required                                                            | 15 GB                      | 100GB+                                | 50GB+         |
-| Memory required                                                           | 1.5 GB                     | 50GB+                                 | variable      |
+| Memory required                                                           | 4 GB                       | 50GB+                                 | variable      |
 | Deployment                                                                | `vagrant up`               | Ops Manager                           | `bosh deploy` |
 | Estimated time-to-deploy                                                  | 10 Minutes                 | Hour+                                 | Hour+         |
 | Out-of-the-Box Services                                                   | Redis<br>MySQL<br>RabbitMQ | Redis<br>MySQL<br>RabbitMQ<br>GemFire | N/A           |


### PR DESCRIPTION
While processes inside the VM technically consume 1.5 GB, the VM itself should reserve 4 GB of host memory.

In the future, can I push small changes like this directly to master? I've received conflicting answers about this.
