### PR TITLE
Correct the memory requirement from 2 GB to 3 GB

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -39,7 +39,7 @@ PCF Dev mirrors [PCF](../pivotalcf/installing/pcf-docs.html) in its key product 
 |                                                                           | PCF Dev                    | PCF                                   | CF            |
 | ---                                                                       | ---                        | ---                                   | ---           |
 | Space required                                                            | 20 GB                      | 100GB+                                | 50GB+         |
-| Memory required                                                           | 2 GB                       | 50GB+                                 | variable      |
+| Memory required                                                           | 3 GB                       | 50GB+                                 | variable      |
 | Deployment                                                                | `vagrant up`               | Ops Manager                           | `bosh deploy` |
 | Estimated time-to-deploy                                                  | 10 Minutes                 | Hour+                                 | Hour+         |
 | Out-of-the-Box Services                                                   | Redis<br>MySQL<br>RabbitMQ | Redis<br>MySQL<br>RabbitMQ<br>GemFire | N/A           |


### PR DESCRIPTION
Correct the memory requirement from 2 GB to 3 GB as https://github.com/pivotal-cf/docs-pcf-dev/commit/70e744466645dbdcfd15c2ac096b452554e68755
