### PR TITLE
Keep PCF Dev name consistent.

### DIFF
--- a/install-linux.html.md.erb
+++ b/install-linux.html.md.erb
@@ -26,7 +26,7 @@ PCF Dev uses the [Cloud Foundry Command Line Interface](https://github.com/cloud
 
 ## <a id="install-pcf-dev"></a>Install PCF Dev
 
-1. Download the latest version of PCF Dev CLI plugin from the [Pivotal Network](https://network.pivotal.io/).
+1. Download the latest version of PCF Dev from the [Pivotal Network](https://network.pivotal.io/).
 1. Unzip the downloaded zip file:
 <pre class="terminal">$ unzip pcfdev-VERSION-linux.zip</pre>
 1. Install the PCF Dev plugin:

--- a/install-osx.html.md.erb
+++ b/install-osx.html.md.erb
@@ -38,7 +38,7 @@ PCF Dev uses the [Cloud Foundry Command Line Interface](https://github.com/cloud
 
 ## <a id="install-pcf-dev"></a>Install PCF Dev
 
-1. Download the latest version of PCF Dev CLI plugin from the [Pivotal Network](https://network.pivotal.io/).
+1. Download the latest version of PCF Dev from the [Pivotal Network](https://network.pivotal.io/).
 1. Unzip the downloaded zip file:
 <pre class="terminal">$ unzip pcfdev-VERSION-osx.zip</pre>
 1. Install the PCF Dev plugin:

--- a/install-windows.html.md.erb
+++ b/install-windows.html.md.erb
@@ -28,7 +28,7 @@ PCF Dev uses the [Cloud Foundry Command Line Interface](https://github.com/cloud
 
 ## <a id="install-pcf-dev"></a>Install PCF Dev
 
-1. Download the latest version of PCF Dev CLI plugin from the [Pivotal Network](https://network.pivotal.io/).
+1. Download the latest version of PCF Dev from the [Pivotal Network](https://network.pivotal.io/).
 1. Unzip the downloaded zip file.
 1. Using PowerShell, navigate to the directory containing the unzipped plugin file.
 1. Install the PCF Dev plugin:


### PR DESCRIPTION
In particular, “PCF Dev CLI plugin” -> “PCF Dev”.
