### PR TITLE
Fix Apps Manager Link

### DIFF
--- a/usage-scs.html.md.erb
+++ b/usage-scs.html.md.erb
@@ -116,7 +116,7 @@ To create a service instance of the Config Server using the cook sample app, per
 
 ## <a id='manage-scs'></a>Manage Spring Cloud Services ##
 
-To manage an SCS instance within PCF Dev, navigate to [Apps Manager](https://local.pcfdev.io) and log in using the admin credentials. Instances of the SCS services are displayed in the **instances** space of the **p-spring-cloud-services** org. See the [Use Apps Manager](./usage.html#apps-manager) topic for more information.
+To manage an SCS instance within PCF Dev, navigate to [Apps Manager](https://apps.local.pcfdev.io) and log in using the admin credentials. Instances of the SCS services are displayed in the **instances** space of the **p-spring-cloud-services** org. See the [Use Apps Manager](./usage.html#apps-manager) topic for more information.
 
  <img src="images/scs-apps-manager.png" alt="SCS Apps Manager"/>
 


### PR DESCRIPTION
The Apps Manager link is broken. I believe it should be `https://apps.local.pcfdev.io` rather than `https://local.pcfdev.io`