### PR TITLE
Changed instances of cf dev start -f .ISO-FILE to .FILE and clarified…

### DIFF
--- a/install-osx.html.md.erb
+++ b/install-osx.html.md.erb
@@ -29,10 +29,10 @@ PCF Dev uses the [Cloud Foundry Command Line Interface](https://github.com/cloud
 1. Download the latest version of PCF Dev from the [Pivotal Network](https://network.pivotal.io/).
 1. Install the CF Dev plugin required to run PCF Dev:
 <pre class="terminal">$ cf install-plugin cfdev</pre>
-1. Start PCF Dev. Enter the following command, replacing `.ISO-FILE` with the name of the .iso file you downloaded:
+1. Start PCF Dev. Enter the following command, replacing `.FILE` with the name of the .iso or .tgz file you downloaded:
 
 	```
-	cf dev start -f .ISO-FILE
+	cf dev start -f .FILE
 	```
   It may take several minutes for the PCF Dev VM and its services to start.
 

--- a/install-windows.html.md.erb
+++ b/install-windows.html.md.erb
@@ -33,10 +33,10 @@ PCF Dev uses the [Cloud Foundry Command Line Interface](https://github.com/cloud
 1. Download the latest version of PCF Dev from the [Pivotal Network](https://network.pivotal.io/).
 1. In PowerShell, install the CF Dev plugin required to run PCF Dev:
 <pre class="terminal">$ cf install-plugin cfdev</pre>
-1. Start PCF Dev. Enter the following command, replacing `.ISO-FILE` with the name of the .iso file you downloaded:
+1. Start PCF Dev. Enter the following command, replacing `.FILE` with the name of the .iso or .tgz file you downloaded:
 
 	```
-	cf dev start -f .ISO-FILE
+	cf dev start -f .FILE
 	```
   It may take several minutes for the PCF Dev VM and its services to start.
   <p class="note"><strong>Note</strong>: You must run PowerShell in Administrator mode with PCF Dev.</p>

--- a/telemetry.html.md.erb
+++ b/telemetry.html.md.erb
@@ -39,7 +39,7 @@ The event data point is collected to understand how the CLI is used. We only cap
 
 The following user events are captured:
 
-* **Begin Start**: When a user runs `cf dev start -f .ISO-FILE`.
+* **Begin Start**: When a user runs `cf dev start -f .FILE`.
 * **Start Finish**: When `cf dev start` finishes starting up.
 * **Error**: When a user encounters an error while using the tool.
 * **Stop**: When a user runs `cf dev stop`.


### PR DESCRIPTION
… .iso or .tgz

Since the change from supplying .ISOs to .tgzs, docs had not been updated.